### PR TITLE
Fix build errors on macos 14/xcode 15.3

### DIFF
--- a/buildlibs.sh
+++ b/buildlibs.sh
@@ -234,7 +234,7 @@ function buildMVK()
 		./fetchDependencies --ios -v
 		make ios
 		cd ..
-		cp $MVK_DIR/Package/Release/MoltenVK/MoltenVK.xcframework/ios-arm64/libMoltenVK.a ./release/ios/device/libMoltenVK.a
+		cp $MVK_DIR/Package/Release/MoltenVK/static/MoltenVK.xcframework/ios-arm64/libMoltenVK.a ./release/ios/device/libMoltenVK.a
 	fi
 
 	# tvOS Simulator

--- a/updatelibs.sh
+++ b/updatelibs.sh
@@ -61,5 +61,5 @@ fi
 
 if [ ! -d "./MoltenVK" ]; then
 	echo "MoltenVK folder not found. Cloning now..."
-	git clone --recursive https://github.com/KhronosGroup/MoltenVK --branch v1.1.4 --single-branch
+	git clone --recursive https://github.com/KhronosGroup/MoltenVK --branch v1.2.9 --single-branch
 fi


### PR DESCRIPTION
This updates the MoltenVK version as upstream has fixed some build errors while building on xcode 15.3 in a newer version.